### PR TITLE
Handle HTTP error responses

### DIFF
--- a/PushoverClient/Pushover.cs
+++ b/PushoverClient/Pushover.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ServiceStack.Text;
+using System.Net;
 
 namespace PushoverClient
 {
@@ -62,8 +63,6 @@ namespace PushoverClient
         /// <returns></returns>
         public PushResponse Push(string title, string message, string userKey = "", string device = "")
         {
-            PushResponse retval = new PushResponse();
-
             //  Try the passed user key first
             string userGroupKey = userKey;
 
@@ -81,10 +80,14 @@ namespace PushoverClient
                 title = title,
                 message = message
             };
-
-            retval = _baseAPIUrl.PostToUrl(args).FromJson<PushResponse>();
-
-            return retval;
+            try
+            {
+                return _baseAPIUrl.PostToUrl(args).FromJson<PushResponse>();
+            }
+            catch (WebException webEx)
+            {
+                return webEx.GetResponseBody().FromJson<PushResponse>();
+            }
         }
     }
 }


### PR DESCRIPTION
When invalid application or user keys are used in the request, the
Pushover server returns HTTP status 400.

Parse the JSON response into an PushResponse object instead of
throwing a WebException. Refs #2.