### PR TITLE
Added retry and expire parameters

### DIFF
--- a/PushoverClient.Tests/ClientTests.cs
+++ b/PushoverClient.Tests/ClientTests.cs
@@ -92,6 +92,23 @@ namespace PushoverClient.Tests
         }
 
         [TestMethod]
+        public async Task PushWithEmergencyPriority_ReturnsSuccessful()
+        {
+          // Arrange
+          var title = "Test title";
+          var message = "This is a test push notification message";
+          var priority = Priority.Emergency;
+
+          //  Act
+          var pclient = new Pushover(TEST_APP_KEY) { DefaultUserGroupSendKey = TEST_USER_KEY };
+          var response = await pclient.PushAsync(title, message, priority: priority);
+
+          //  Assert
+          Assert.IsNotNull(response);
+          Assert.AreEqual(1, response.Status);
+        }
+
+        [TestMethod]
         public async Task PushWithSound_ReturnsSuccessful()
         {
             //  Arrange

--- a/PushoverClient/PushOverRequestArguments.cs
+++ b/PushoverClient/PushOverRequestArguments.cs
@@ -11,5 +11,7 @@ namespace PushoverClient
         public int priority { get; set; }
         public int timestamp { get; set; }
         public string sound { get; set; }
+        public int retry { get; set; }
+        public int expire { get; set; }
     }
 }

--- a/PushoverClient/Pushover.cs
+++ b/PushoverClient/Pushover.cs
@@ -35,6 +35,21 @@ namespace PushoverClient
         }
 
         /// <summary>
+        /// The interval (in seconds) between repeating notifications for
+        /// <see cref="Priority.Emergency"/> priority messages. Pushover
+        /// servers keep sending emergency priority messages until they
+        /// are either acknowledged or the acknowledgement time expires
+        /// (<see cref="EmergencyExpiryInterval"/>).
+        /// </summary>
+        public int EmergencyRetryInterval { get; set; } = 60; // Seconds
+
+        /// <summary>
+        /// The interval (in seconds) before <see cref="Priority.Emergency"/>
+        /// messages expire. 
+        /// </summary>
+        public int EmergencyExpiryInterval { get; set; } = 300; // Seconds;
+
+        /// <summary>
         /// Create a pushover client using a source application key.
         /// </summary>
         /// <param name="appKey"></param>
@@ -126,6 +141,12 @@ namespace PushoverClient
             if (notificationSound != NotificationSound.NotSet)
             {
                 args.sound = notificationSound.ToString().ToLower();
+            }
+
+            if (priority == Priority.Emergency)
+            {
+                args.retry = EmergencyRetryInterval;
+                args.expire = EmergencyExpiryInterval;
             }
 
             return args;


### PR DESCRIPTION
Notifications with `Emergency` priority fail without `retry` and `expire` parameters. (see [message priority](https://pushover.net/api#priority)). 

Added these parameters. 