### PR TITLE
Adding The Ability To Send Attachments

### DIFF
--- a/PushoverClient/Pushover.cs
+++ b/PushoverClient/Pushover.cs
@@ -1,6 +1,8 @@
-﻿using ServiceStack;
+﻿using Newtonsoft.Json;
 using System;
+using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace PushoverClient
@@ -16,6 +18,11 @@ namespace PushoverClient
         /// </summary>
         private const string BASE_API_URL = "https://api.pushover.net/1/messages.json";
 
+        /// <summary>
+        /// The shared http client
+        /// </summary>
+        private readonly HttpClient Client = new HttpClient();
+        
         /// <summary>
         /// The application key
         /// </summary>
@@ -63,18 +70,14 @@ namespace PushoverClient
         /// <param name="device">Send to a specific device</param>
         /// <param name="priority">Priority of the message (optional) default value set to Normal</param>
         /// <param name="notificationSound">If set sends the notification sound</param>
+        /// <param name="attachment">If set sends a file attachment</param>
         /// <returns></returns>
-        public PushResponse Push(string title, string message, string userKey = "", string device = "", Priority priority = Priority.Normal, DateTime? timestamp = null, NotificationSound notificationSound = NotificationSound.NotSet)
+        public PushResponse Push(string title, string message, string userKey = "", string device = "", Priority priority = Priority.Normal, DateTime? timestamp = null, NotificationSound notificationSound = NotificationSound.NotSet, PushoverFileAttachment attachment = null)
         {
-            var args = CreateArgs(title, message, userKey, device, priority, timestamp ?? DateTime.UtcNow, notificationSound);
-            try
-            {
-                return BASE_API_URL.PostToUrl(args).FromJson<PushResponse>();
-            }
-            catch (WebException webEx)
-            {
-                return webEx.GetResponseBody().FromJson<PushResponse>();
-            }
+            ValidateAttachment(attachment);
+            var task = PostAsync(CreateArgs(title, message, userKey, device, priority, timestamp ?? DateTime.UtcNow, notificationSound), attachment);
+            task.Wait();
+            return task.Result;
         }
 
         /// <summary>
@@ -86,23 +89,15 @@ namespace PushoverClient
         /// <param name="device">Send to a specific device</param>
         /// <param name="priority">Priority of the message (optional) default value set to Normal</param>
         /// <param name="notificationSound">If set sends the notification sound</param>
+        /// <param name="attachment">If set sends a file attachment</param>
         /// <returns></returns>
-        public async Task<PushResponse> PushAsync(string title, string message, string userKey = "", string device = "", Priority priority = Priority.Normal, DateTime? timestamp = null, NotificationSound notificationSound = NotificationSound.NotSet)
+        public async Task<PushResponse> PushAsync(string title, string message, string userKey = "", string device = "", Priority priority = Priority.Normal, DateTime? timestamp = null, NotificationSound notificationSound = NotificationSound.NotSet, PushoverFileAttachment attachment = null)
         {
-            var args = CreateArgs(title, message, userKey, device, priority, timestamp?? DateTime.UtcNow, notificationSound);
-            try
-            {
-                return (await BASE_API_URL.PostToUrlAsync(args)).FromJson<PushResponse>();
-            }
-            catch (WebException webEx)
-            {
-                return webEx.GetResponseBody().FromJson<PushResponse>();
-            }
+            ValidateAttachment(attachment);
+            return await PostAsync(CreateArgs(title, message, userKey, device, priority, timestamp ?? DateTime.UtcNow, notificationSound), attachment);          
         }
 
-
-
-        private object CreateArgs(string title, string message, string userKey, string device, Priority priority, DateTime timestamp, NotificationSound notificationSound)
+        private PushoverRequestArguments CreateArgs(string title, string message, string userKey, string device, Priority priority, DateTime timestamp, NotificationSound notificationSound)
         {
             // Try the passed user key or fall back to default
             var userGroupKey = string.IsNullOrEmpty(userKey) ? DefaultUserGroupSendKey : userKey;
@@ -131,6 +126,74 @@ namespace PushoverClient
             return args;
         }
 
+        private void ValidateAttachment(PushoverFileAttachment attachment)
+        {
+            // No attachment is fine.
+            if(attachment == null)
+            {
+                return;
+            }
+            attachment.Validate();
+        }
 
+        private async Task<PushResponse> PostAsync(PushoverRequestArguments args, PushoverFileAttachment attachment)
+        {
+            StreamContent fileContent = null;
+            try
+            {
+                using (var content = new MultipartFormDataContent())
+                {
+                    // Add the required fields (or their defaults)
+                    content.Add(new StringContent(args.token), "token");
+                    content.Add(new StringContent(args.user), "user");
+                    content.Add(new StringContent(args.device), "device");
+                    content.Add(new StringContent(args.title), "title");
+                    content.Add(new StringContent(args.message), "message");
+                    content.Add(new StringContent(args.timestamp.ToString()), "timestamp");
+                    content.Add(new StringContent(args.priority.ToString()), "priority");
+
+                    // Add the attachment if there is one.
+                    if (attachment != null)
+                    {
+                        fileContent = new StreamContent(attachment.FileStream);
+                        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(attachment.ContentType);
+                        fileContent.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("form-data")
+                        {
+                            Name = "attachment",
+                            FileName = attachment.FileName
+                        };
+                        content.Add(fileContent);
+                    }
+
+                    // Make the request.
+                    try
+                    {
+                        var result = await Client.PostAsync(BASE_API_URL, content);
+                        // Always try to read the body as the expected json result, even if the status code is not OK.
+                        return await ReadStreamAsync(await result.Content.ReadAsStreamAsync());
+                    }
+                    catch (WebException webEx)
+                    {
+                        return await ReadStreamAsync(webEx.Response.GetResponseStream());
+                    }
+                }
+            }
+            finally
+            {
+                // Dispose of the file content, if there is one.
+                if(fileContent != null)
+                {
+                    fileContent.Dispose();
+                }
+            }
+        }
+
+        private async Task<PushResponse> ReadStreamAsync(Stream s)
+        {
+            using (var sr = new StreamReader(s))
+            {
+                return JsonConvert.DeserializeObject<PushResponse>(await sr.ReadToEndAsync());
+            }
+        }
     }
 }

--- a/PushoverClient/PushoverClient.csproj
+++ b/PushoverClient/PushoverClient.csproj
@@ -35,15 +35,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.0.2\lib\net45\ServiceStack.Text.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -52,6 +47,7 @@
     <Compile Include="Priority.cs" />
     <Compile Include="Pushover.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PushoverFileAttachment.cs" />
     <Compile Include="PushOverRequestArguments.cs" />
     <Compile Include="PushResponse.cs" />
   </ItemGroup>

--- a/PushoverClient/PushoverClient.csproj
+++ b/PushoverClient/PushoverClient.csproj
@@ -35,8 +35,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data" />

--- a/PushoverClient/PushoverFileAttachment.cs
+++ b/PushoverClient/PushoverFileAttachment.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PushoverClient
+{
+    public class PushoverFileAttachment
+    {
+        public PushoverFileAttachment(string fileName, string contentType, Stream stream)
+        {
+            FileName = fileName;
+            ContentType = contentType;
+            FileStream = stream;
+            Validate();
+        }
+
+        public string FileName { get; set; }
+        public string ContentType { get; set; }
+        public Stream FileStream { get; set; }
+
+        public void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(FileName))
+            {
+                throw new ArgumentException("File attachment FileName is required");
+            }            
+            if (string.IsNullOrWhiteSpace(ContentType))
+            {
+                throw new ArgumentException("File attachment ContentType is required");
+            }
+            if (FileStream == null)
+            {
+                throw new ArgumentException("File attachment FileStream is required");
+            }
+            if (!FileStream.CanRead)
+            {
+                throw new ArgumentException("File attachment FileStream must be readable.");
+            }
+        }
+    }
+}

--- a/PushoverClient/packages.config
+++ b/PushoverClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack.Text" version="5.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
I wanted to send attachments (images) so I added it!

I had to move away from ServiceStack, since I wasn't able to make it support the file attachments as part of the post. But the API signature hasn't changed at all, beyond adding the new attachments object.